### PR TITLE
Set priority to high for Android devices

### DIFF
--- a/lib/modulofcm/client.rb
+++ b/lib/modulofcm/client.rb
@@ -136,7 +136,9 @@ module Modulofcm
         }
       else
         {
-          android: {},
+          android: { 
+            priority: "high" 
+          },
           apns: {
             payload: {
               aps: {


### PR DESCRIPTION
# Required for background/terminated app state messages on Android